### PR TITLE
Adding support to mimic3 server to allow user to specify voices that have alternate speakers

### DIFF
--- a/programs/tts/mimic3/bin/mimic3_server.py
+++ b/programs/tts/mimic3/bin/mimic3_server.py
@@ -51,7 +51,11 @@ def main() -> None:
         )
 
         _LOGGER.debug("Preloading voice: %s", args.voice)
-        mimic3.preload_voice(args.voice)
+        if "#" in args.voice:
+            # Case to handle a multi-speaker voice definition
+            mimic3.preload_voice(args.voice[0:args.voice.index('#')])
+        else:
+            mimic3.preload_voice(args.voice)
         _LOGGER.info("Ready")
 
         mimic3.voice = args.voice


### PR DESCRIPTION
Allows the user to specify voices with multi-speakers (for example vctk_low#p238) on the mimic3 server/configs