### PR TITLE
agent_id parameter for home assistant

### DIFF
--- a/programs/handle/home_assistant/bin/converse.py
+++ b/programs/handle/home_assistant/bin/converse.py
@@ -19,6 +19,7 @@ def main():
     )
     parser.add_argument("token_file", help="Path to file with authorization token")
     parser.add_argument("--language", help="Language code to use")
+    parser.add_argument("--agent_id", help="ID of conversation agent. The conversation agent is the brains of the assistant. It processes the incoming text commands")
     parser.add_argument(
         "--debug", action="store_true", help="Print DEBUG messages to console"
     )
@@ -31,6 +32,8 @@ def main():
     data_dict = {"text": sys.stdin.read()}
     if args.language:
         data_dict["language"] = args.language
+    if args.agent_id:
+        data_dict["agent_id"] = args.agent_id
 
     data = json.dumps(data_dict, ensure_ascii=False).encode("utf-8")
     request = Request(args.url, data=data, headers=headers)

--- a/rhasspy3/configuration.yaml
+++ b/rhasspy3/configuration.yaml
@@ -389,12 +389,13 @@ programs:
     # 2. Put long-lived access token in etc/token
     home_assistant:
       command: |
-        bin/converse.py --language "${language}" "${url}" "${token_file}"
+        bin/converse.py --language "${language}" --agent_id "${agent_id}" "${url}" "${token_file}"
       adapter: |
         handle_adapter_text.py
       template_args:
         url: "http://localhost:8123/api/conversation/process"
         token_file: "${data_dir}/token"
+        agent_id: "homeassistant"
         language: ""
 
     # Intent only: answer English date/time requests


### PR DESCRIPTION
Allows to select an alternate conversation agent, such as [OpenAI Conversation](https://www.home-assistant.io/integrations/openai_conversation/).