### PR TITLE
Native pulseaudio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ See `servers` section of `configuration.yaml` file.
 
 * mic
     * [arecord](https://alsa-project.org/wiki/Main_Page)
+    * [parecord](https://www.freedesktop.org/wiki/Software/PulseAudio/)
     * [gstreamer_udp](https://gstreamer.freedesktop.org/)
     * [sounddevice](https://python-sounddevice.readthedocs.io)
     * [pyaudio](https://people.csail.mit.edu/hubert/pyaudio/docs/)
@@ -118,6 +119,7 @@ See `servers` section of `configuration.yaml` file.
     * [espeak-ng](https://github.com/espeak-ng/espeak-ng/)
 * snd
     * [aplay](https://alsa-project.org/wiki/Main_Page)
+    * [paplay](https://www.freedesktop.org/wiki/Software/PulseAudio/)
     * [gstreamer_udp](https://gstreamer.freedesktop.org/)
     
     

--- a/rhasspy3/configuration.yaml
+++ b/rhasspy3/configuration.yaml
@@ -14,6 +14,13 @@ programs:
       template_args:
         device: "default"
 
+    # apt-get install pulseaudio-utils
+    parecord:
+      command: |
+        parecord --client-name=rhasspy_mic --rate=16000 --channels=1 --format=s16le --raw --property=media.software=Rhasspy
+      adapter: |
+        mic_adapter_raw.py --rate 16000 --width 2 --channels 1
+
     # https://people.csail.mit.edu/hubert/pyaudio/docs/
     pyaudio:
       command: |
@@ -426,6 +433,13 @@ programs:
         snd_adapter_raw.py --rate 22050 --width 2 --channels 1
       template_args:
         device: "default"
+
+    # apt-get install pulseaudio-utils
+    paplay:
+      command: |
+        paplay --rate=22050 --format=s16le --channels=1 --raw --property=media.software=Rhasspy
+      adapter: |
+        snd_adapter_raw.py --rate 22050 --width 2 --channels 1
 
     udp_raw:
       command: |


### PR DESCRIPTION
This is a small PR that documents the use of native pulseaudio tools (`parecord`/`pareceive`) for Pulseaudio and Pipewire users.