### PR TITLE
handle_adapter_text multiline

### DIFF
--- a/bin/handle_adapter_text.py
+++ b/bin/handle_adapter_text.py
@@ -54,12 +54,19 @@ def main() -> None:
                 handled = False
                 for line in stdout.splitlines():
                     line = line.strip()
-                    if line:
-                        write_event(Handled(text=line).event())
+                    if not line:
+                        continue
+                    if not line.endswith(('.', ',', ':', '?', ';')):
+                        line = line + "."
+                    if not handled:
+                        text = line
                         handled = True
-                        break
+                    else:
+                        text = text + " " + line
 
-                if not handled:
+                if handled:
+                    write_event(Handled(text=text).event())
+                else:
                     write_event(NotHandled().event())
 
                 break


### PR DESCRIPTION
If a handler process returns multi-line text, then join the lines in the adapter instead of using the first line only.
Fixes #34 