### PR TITLE
Allow tensorflow in place of tflite

### DIFF
--- a/programs/wake/openwakeword-lite/bin/server/openwakeword.py
+++ b/programs/wake/openwakeword-lite/bin/server/openwakeword.py
@@ -3,7 +3,10 @@ import logging
 from typing import List
 
 import numpy as np
-import tflite_runtime.interpreter as tflite
+try:
+    import tflite_runtime.interpreter as tflite
+except ModuleNotFoundError:
+    import tensorflow.lite as tflite
 
 from wyoming.wake import Detection
 

--- a/programs/wake/openwakeword-lite/server/wyoming_openwakeword/openwakeword.py
+++ b/programs/wake/openwakeword-lite/server/wyoming_openwakeword/openwakeword.py
@@ -4,7 +4,10 @@ from datetime import datetime
 from typing import List, Optional, TextIO
 
 import numpy as np
-import tflite_runtime.interpreter as tflite
+try:
+    import tflite_runtime.interpreter as tflite
+except ModuleNotFoundError:
+    import tensorflow.lite as tflite
 
 from wyoming.wake import Detection
 

--- a/programs/wake/precise-lite/bin/precise_shared.py
+++ b/programs/wake/precise-lite/bin/precise_shared.py
@@ -24,7 +24,10 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 import numpy as np
-import tflite_runtime.interpreter as tflite
+try:
+    import tflite_runtime.interpreter as tflite
+except ModuleNotFoundError:
+    import tensorflow.lite as tflite
 from sonopy import mfcc_spec
 
 MAX_WAV_VALUE = 32768


### PR DESCRIPTION
As a distro, we are packaging tensorflow, but not tflite. The latter is a small cut-out of tensorflow, so they share the same entrypoint.

```
>>> import tensorflow.lite as tflite
2023-09-29 21:46:53.737907: I tensorflow/core/util/port.cc:110] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2023-09-29 21:46:53.755324: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
>>> tflite.Interpreter
<class 'tensorflow.lite.python.interpreter.Interpreter'>
```

This allows us to provide tensorflow in place of tflite, at the cost of a higher runtime closure size, but reduced maintenance load.