### PR TITLE
Add commandline entrypoints

### DIFF
--- a/programs/asr/faster-whisper/server/setup.py
+++ b/programs/asr/faster-whisper/server/setup.py
@@ -35,4 +35,9 @@ setup(
         "Programming Language :: Python :: 3.10",
     ],
     keywords="rhasspy wyoming whisper",
+    entry_points={
+        'console_scripts': [
+            'wyoming-faster-whisper = wyoming_faster_whisper:__main__.run'
+        ]
+    },
 )

--- a/programs/asr/faster-whisper/server/wyoming_faster_whisper/__main__.py
+++ b/programs/asr/faster-whisper/server/wyoming_faster_whisper/__main__.py
@@ -131,8 +131,13 @@ async def main() -> None:
 
 # -----------------------------------------------------------------------------
 
+
+def run():
+    asyncio.run(main())
+
+
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        run()
     except KeyboardInterrupt:
         pass

--- a/programs/tts/piper/server/setup.py
+++ b/programs/tts/piper/server/setup.py
@@ -41,4 +41,9 @@ setup(
         "Programming Language :: Python :: 3.10",
     ],
     keywords="rhasspy wyoming piper",
+    entry_points={
+        'console_scripts': [
+            'wyoming-piper = wyoming_piper:__main__.run'
+        ]
+    },
 )

--- a/programs/tts/piper/server/wyoming_piper/__main__.py
+++ b/programs/tts/piper/server/wyoming_piper/__main__.py
@@ -188,8 +188,13 @@ def get_description(voice_info: Dict[str, Any]):
 
 # -----------------------------------------------------------------------------
 
+
+def run():
+    asyncio.run(main())
+
+
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        run()
     except KeyboardInterrupt:
         pass

--- a/programs/wake/openwakeword-lite/server/setup.py
+++ b/programs/wake/openwakeword-lite/server/setup.py
@@ -40,4 +40,9 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     keywords="rhasspy wyoming openwakeword",
+    entry_points={
+        'console_scripts': [
+            'wyoming-openwakeword = wyoming_openwakeword:__main__.run'
+        ]
+    },
 )

--- a/programs/wake/openwakeword-lite/server/wyoming_openwakeword/__main__.py
+++ b/programs/wake/openwakeword-lite/server/wyoming_openwakeword/__main__.py
@@ -169,8 +169,12 @@ async def main() -> None:
 
 # -----------------------------------------------------------------------------
 
+def run():
+    asyncio.run(main())
+
+
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        run()
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
With this change instead of calling `python -m wyoming_piper` I can now call `wyoming-piper`, because the entrypoint gets linked into a directory that is commonly in the PATH.