### PR TITLE
Start listening again after vad

### DIFF
--- a/bin/pipeline_run.py
+++ b/bin/pipeline_run.py
@@ -104,26 +104,89 @@ async def main() -> None:
 
     rhasspy = Rhasspy.load(args.config)
 
+    if not args.loop or args.stop_after in ("wake", "asr"):
+        while True:
+            pipeline_result = await run_pipeline(
+                rhasspy,
+                args.pipeline,
+                samples_per_chunk=args.samples_per_chunk,
+                asr_chunks_to_buffer=args.asr_chunks_to_buffer,
+                wake_detection=wake_detection,
+                asr_wav_in=asr_wav_in,
+                asr_transcript=asr_transcript,
+                intent_result=intent_result,
+                handle_result=handle_result,
+                tts_wav_in=tts_wav_in,
+                stop_after=args.stop_after,
+            )
+
+            json.dump(pipeline_result.to_dict(), sys.stdout, ensure_ascii=False)
+            print("")
+
+            if not args.loop:
+                break
+
+    response_task = None
     while True:
-        pipeline_result = await run_pipeline(
-            rhasspy,
-            args.pipeline,
-            samples_per_chunk=args.samples_per_chunk,
-            asr_chunks_to_buffer=args.asr_chunks_to_buffer,
-            wake_detection=wake_detection,
-            asr_wav_in=asr_wav_in,
-            asr_transcript=asr_transcript,
-            intent_result=intent_result,
-            handle_result=handle_result,
-            tts_wav_in=tts_wav_in,
-            stop_after=args.stop_after,
+        request_task = asyncio.create_task(
+            run_pipeline(
+                rhasspy,
+                args.pipeline,
+                samples_per_chunk=args.samples_per_chunk,
+                asr_chunks_to_buffer=args.asr_chunks_to_buffer,
+                wake_detection=wake_detection,
+                asr_wav_in=asr_wav_in,
+                asr_transcript=asr_transcript,
+                stop_after="asr",
+            )
         )
 
-        json.dump(pipeline_result.to_dict(), sys.stdout, ensure_ascii=False)
-        print("")
+        aws = [request_task]
+        if response_task is not None and not response_task.done():
+            aws.append(response_task)
 
-        if not args.loop:
-            break
+        while True:
+            done, pending = await asyncio.wait(aws, return_when=asyncio.FIRST_COMPLETED)
+
+            if response_task is not None and response_task in done:
+                if not response_task.cancelled():
+                    pipeline_result = response_task.result()
+                json.dump(pipeline_result.to_dict(), sys.stdout, ensure_ascii=False)
+                print("")
+                response_task = None
+
+            if (
+                request_task in done
+                and response_task is not None
+                and response_task in pending
+            ):
+                response_task.cancel()
+
+            aws = pending
+            if not len(aws):
+                break
+
+        pipeline_result = request_task.result()
+
+        if pipeline_result.asr_transcript is None:
+            json.dump(pipeline_result.to_dict(), sys.stdout, ensure_ascii=False)
+            print("")
+            continue
+
+        response_task = asyncio.create_task(
+            run_pipeline(
+                rhasspy,
+                args.pipeline,
+                samples_per_chunk=args.samples_per_chunk,
+                asr_chunks_to_buffer=args.asr_chunks_to_buffer,
+                wake_detection=pipeline_result.wake_detection,
+                asr_transcript=pipeline_result.asr_transcript,
+                intent_result=intent_result,
+                handle_result=handle_result,
+                tts_wav_in=tts_wav_in,
+                stop_after=args.stop_after,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/rhasspy3/pipeline.py
+++ b/rhasspy3/pipeline.py
@@ -158,7 +158,9 @@ async def run(
                 await run_command(rhasspy, asr_after)
 
             asr_transcript = pipeline_result.asr_transcript
-            pipeline_result.asr_transcript = asr_transcript
+            wake_detection = pipeline_result.wake_detection
+        pipeline_result.asr_transcript = asr_transcript
+        pipeline_result.wake_detection = wake_detection
 
     if (stop_after == StopAfterDomain.ASR) or (
         (intent_program is None) and (handle_program is None)

--- a/rhasspy3/pipeline.py
+++ b/rhasspy3/pipeline.py
@@ -1,6 +1,7 @@
 """Full voice loop (pipeline)."""
 import io
 import logging
+from asyncio import Future
 from collections import deque
 from dataclasses import dataclass, fields
 from enum import Enum
@@ -62,10 +63,12 @@ async def run(
     mic_program: Optional[Union[str, PipelineProgramConfig]] = None,
     wake_program: Optional[Union[str, PipelineProgramConfig]] = None,
     wake_detection: Optional[Detection] = None,
+    wake_future: Optional[Future] = None,
     asr_program: Optional[Union[str, PipelineProgramConfig]] = None,
     asr_wav_in: Optional[IO[bytes]] = None,
     asr_transcript: Optional[Transcript] = None,
     vad_program: Optional[Union[str, PipelineProgramConfig]] = None,
+    vad_future: Optional[Future] = None,
     intent_result: Optional[Union[Intent, NotRecognized]] = None,
     intent_program: Optional[Union[str, PipelineProgramConfig]] = None,
     handle_result: Optional[Union[Handled, NotHandled]] = None,
@@ -125,21 +128,22 @@ async def run(
                 assert asr_program is not None, "No asr program"
                 assert vad_program is not None, "No vad program"
                 await _mic_asr(
-                    rhasspy, mic_program, asr_program, vad_program, pipeline_result
+                    rhasspy, mic_program, asr_program, vad_program, pipeline_result, vad_future
                 )
             elif stop_after == StopAfterDomain.WAKE:
                 # Audio input, wake word detection, segmentation, speech to text
-                assert wake_program is not None, "No vad program"
+                assert wake_program is not None, "No wake program"
                 await _mic_wake(
                     rhasspy,
                     mic_program,
                     wake_program,
                     pipeline_result,
                     wake_detection=wake_detection,
+                    wake_future=wake_future,
                 )
                 return pipeline_result
             else:
-                assert wake_program is not None, "No vad program"
+                assert wake_program is not None, "No wake program"
                 assert asr_program is not None, "No asr program"
                 assert vad_program is not None, "No vad program"
                 await _mic_wake_asr(
@@ -152,6 +156,8 @@ async def run(
                     asr_chunks_to_buffer=asr_chunks_to_buffer,
                     wake_detection=wake_detection,
                     wake_after=wake_after,
+                    wake_future=wake_future,
+                    vad_future=vad_future,
                 )
 
             if asr_after is not None:
@@ -222,6 +228,7 @@ async def _mic_wake(
     wake_program: Union[str, PipelineProgramConfig],
     pipeline_result: PipelineResult,
     wake_detection: Optional[Detection] = None,
+    wake_future: Optional[Future] = None,
 ):
     """Just wake word detection."""
     async with (await create_process(rhasspy, MIC_DOMAIN, mic_program)) as mic_proc:
@@ -234,6 +241,7 @@ async def _mic_wake(
             )
 
         if wake_detection is not None:
+            wake_future.set_result(wake_detection)
             pipeline_result.wake_detection = wake_detection
         else:
             _LOGGER.debug("run: no wake word detected")
@@ -246,6 +254,7 @@ async def _mic_asr(
     vad_program: Union[str, PipelineProgramConfig],
     pipeline_result: PipelineResult,
     asr_chunks_to_buffer: int = 0,
+    vad_future: Optional[Future] = None,
 ):
     """Just asr transcription (+ silence detection)."""
     async with (await create_process(rhasspy, MIC_DOMAIN, mic_program)) as mic_proc, (
@@ -261,6 +270,7 @@ async def _mic_asr(
             mic_proc.stdout,
             asr_proc.stdin,
         )
+        vad_future.set_result(True)
         while True:
             asr_event = await async_read_event(asr_proc.stdout)
             if asr_event is None:
@@ -281,6 +291,8 @@ async def _mic_wake_asr(
     asr_chunks_to_buffer: int = 0,
     wake_detection: Optional[Detection] = None,
     wake_after: Optional[CommandConfig] = None,
+    wake_future: Optional[Future] = None,
+    vad_future: Optional[Future] = None,
 ):
     """Wake word detect + asr transcription (+ silence detection)."""
     chunk_buffer: Optional[Deque[Event]] = (
@@ -300,6 +312,7 @@ async def _mic_wake_asr(
             )
 
         if wake_detection is not None:
+            wake_future.set_result(wake_detection)
             if wake_after is not None:
                 await run_command(rhasspy, wake_after)
 
@@ -311,6 +324,7 @@ async def _mic_wake_asr(
                 asr_proc.stdin,
                 chunk_buffer,
             )
+            vad_future.set_result(True)
             while True:
                 asr_event = await async_read_event(asr_proc.stdout)
                 if asr_event is None:


### PR DESCRIPTION
With this PR it is now possible to interrupt the response with a wake word and ask a new question without waiting for the full answer. If loop is enabled, when the user stops speaking (after vad), a new iteration of the loop is started right away (if the wake domain is enabled), and if the wake word is detected, the previous iteration is canceled.
Fixes #54 